### PR TITLE
Add minimal Flask housing portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Housing_Portal
-This will be the housing portal that we will use to manage all of our payments for housing happening. 
+
+This repository contains a minimal example of a housing portal using Flask. The portal allows users to submit a payment through Stripe Checkout.
+
+## Requirements
+
+- Python 3.8+
+- Install dependencies using `pip install -r requirements.txt`.
+- Set the environment variables `STRIPE_SECRET_KEY` and `STRIPE_PUBLISHABLE_KEY` with your Stripe credentials.
+
+## Running
+
+```
+python app.py
+```
+
+Navigate to `http://localhost:5000` in your browser to test the payment flow.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+import os
+from flask import Flask, render_template, redirect, url_for, request
+import stripe
+
+app = Flask(__name__)
+
+stripe.api_key = os.environ.get("STRIPE_SECRET_KEY", "sk_test_placeholder")
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/pay', methods=['GET', 'POST'])
+def pay():
+    if request.method == 'POST':
+        try:
+            stripe.Charge.create(
+                amount=1000,
+                currency='usd',
+                description='Housing fee',
+                source=request.form['stripeToken']
+            )
+            return redirect(url_for('success'))
+        except stripe.error.StripeError:
+            return 'Payment error', 400
+    return render_template('pay.html', publishable_key=os.environ.get('STRIPE_PUBLISHABLE_KEY', 'pk_test_placeholder'))
+
+@app.route('/success')
+def success():
+    return render_template('success.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+stripe

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Welcome to the Housing Portal</h1>
+<a class="btn btn-primary" href="{{ url_for('pay') }}">Pay Housing Fee</a>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Housing Portal</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-4">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/pay.html
+++ b/templates/pay.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Pay Housing Fee</h1>
+<form action="/pay" method="post" id="payment-form">
+  <script
+    src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+    data-key="{{ publishable_key }}"
+    data-amount="1000"
+    data-name="Housing Portal"
+    data-description="Housing fee"
+    data-currency="usd"
+    data-locale="auto"
+  ></script>
+</form>
+{% endblock %}

--- a/templates/success.html
+++ b/templates/success.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Payment Successful</h1>
+<p>Thank you for your payment.</p>
+<a class="btn btn-primary" href="/">Return Home</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- set up a Flask app with Stripe integration
- add HTML templates for the index, payment page, and success page
- document setup and running instructions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68537ca4ec94832eb8cebe1162496c1d