### PR TITLE
Add simple login functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Housing_Portal
 
-This repository contains a minimal example of a housing portal using Flask. The portal allows users to submit a payment through Stripe Checkout.
+This repository contains a minimal example of a housing portal using Flask.
+Users can register, log in, and submit a payment through Stripe Checkout.
 
 ## Requirements
 
 - Python 3.8+
 - Install dependencies using `pip install -r requirements.txt`.
 - Set the environment variables `STRIPE_SECRET_KEY` and `STRIPE_PUBLISHABLE_KEY` with your Stripe credentials.
+- Optionally set `FLASK_SECRET_KEY` to configure the session secret.
 
 ## Running
 

--- a/app.py
+++ b/app.py
@@ -1,17 +1,58 @@
 import os
-from flask import Flask, render_template, redirect, url_for, request
+from flask import Flask, render_template, redirect, url_for, request, session
+from werkzeug.security import generate_password_hash, check_password_hash
 import stripe
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "change-me")
 
 stripe.api_key = os.environ.get("STRIPE_SECRET_KEY", "sk_test_placeholder")
+
+# In-memory user store for demo purposes
+users = {
+    'admin': generate_password_hash('password')
+}
 
 @app.route('/')
 def index():
     return render_template('index.html')
 
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if username in users:
+            return 'User already exists', 400
+        users[username] = generate_password_hash(password)
+        session['user'] = username
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        pw_hash = users.get(username)
+        if pw_hash and check_password_hash(pw_hash, password):
+            session['user'] = username
+            return redirect(url_for('index'))
+        return 'Invalid credentials', 401
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('index'))
+
 @app.route('/pay', methods=['GET', 'POST'])
 def pay():
+    if 'user' not in session:
+        return redirect(url_for('login'))
     if request.method == 'POST':
         try:
             stripe.Charge.create(

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,6 +6,31 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Housing Portal</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+        {% if session.get('user') %}
+        <li class="nav-item">
+          <span class="nav-link">Logged in as {{ session['user'] }}</span>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+        </li>
+        {% else %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('register') }}">Register</a>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+
 <div class="container mt-4">
     {% block content %}{% endblock %}
 </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Register</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add user registration and login with session support
- protect the payment page from anonymous access
- display login/logout links in navigation bar
- document authentication in README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578627b0d0832eac43eed7f328aa5a